### PR TITLE
Entity as another entity's field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3407,7 +3407,18 @@
           "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
           "dev": true
         }
-      }
+      },
+        "apollo-link": "^1.2.14",
+        "apollo-utilities": "^1.0.1",
+        "deprecated-decorator": "^0.1.6",
+        "iterall": "^1.1.3",
+        "uuid": "^3.1.0"
+      },
+    "graphql": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.3.0.tgz",
+      "integrity": "sha512-xm+ANmA16BzCT5pLjuXySbQVFwH3oJctUVdy81w1sV0vBU0KgDdBGtxQOUd5zqOBk/JayAFeG8Dlmeq74rjm/A==",
+      "dev": true
     },
     "graceful-fs": {
       "version": "4.2.8",

--- a/src/entity2input.js
+++ b/src/entity2input.js
@@ -19,7 +19,7 @@ function entity2input(entity, options = {}) {
   if (options && options.inputName) name = options.inputName
   else name = convention(entity.name)
 
-  let gql = `input ${name}Input {\n${entityField2gql(entity)}}`
+  let gql = `input ${name}Input {\n${entityField2gql(entity, 'input')}}`
   return gql
 }
 

--- a/src/entity2type.js
+++ b/src/entity2type.js
@@ -21,7 +21,7 @@ function entity2type(entity, options = {}) {
 
   let gql = ""
   gql += `type ${name} {\n`
-  gql += entityField2gql(entity)
+  gql += entityField2gql(entity, 'type')
   gql += "}"
   return gql
 }

--- a/src/helpers/gqlConverters.js
+++ b/src/helpers/gqlConverters.js
@@ -41,16 +41,19 @@ function schemaOptions(options) {
     }, options || {})
 }
 
-function entityFieldType2gql(type) {
+function entityFieldType2gql(type, param) {
     let name
     if (Array.isArray(type)) name = `[${entityFieldType2gql(type[0])}]`
     else if (type === Number) name = `Float`
-    else if (type.prototype instanceof BaseEntity) name = upperFirst(camelCase(type.name))
+    else if (type.prototype instanceof BaseEntity) {
+        if(param=='type')  name = upperFirst(camelCase(type.name))
+        if(param=='input') name=`${upperFirst(camelCase(type.name))}Input`
+    }
     else name = type.name
     return name
 }
 
-function entityField2gql(entity) {
+function entityField2gql(entity, param) {
     const fields = Object.keys(entity.prototype.meta.schema)    
     let gql = ""
     for (const field of fields) {
@@ -59,7 +62,7 @@ function entityField2gql(entity) {
 
         const { type, options } = entity.prototype.meta.schema[field]
 
-        let name = entityFieldType2gql(type)
+        let name = entityFieldType2gql(type, param)
 
         let typeOptions = fieldOptions2gpq(options)
 

--- a/test/entity2input.test.js
+++ b/test/entity2input.test.js
@@ -50,13 +50,12 @@ dateArrayField: [Date]
       // given
       const givenAnFirstEntity = entity("Entity One", {
         numberField: field(Number),
-        nome: field(String)
-        // customEntityFunction: function () { }
+        customEntityFunction: function () { }
       })
 
       const givenAnSecondEntity = entity("Entity Two", {
         entityField: field(givenAnFirstEntity),
-        // customEntityFunction: function () { }
+        customEntityFunction: function () { }
       })
 
       // when
@@ -69,7 +68,6 @@ dateArrayField: [Date]
         gql,
         `input EntityOneInput {
 numberField: Float
-nome: String
 }
       input EntityTwoInput {
 entityField: EntityOneInput

--- a/test/entity2input.test.js
+++ b/test/entity2input.test.js
@@ -46,6 +46,37 @@ dateArrayField: [Date]
       )
     })
 
+     it("should convert an entity to input when entity has entity references", async () => {
+      // given
+      const givenAnFirstEntity = entity("Entity One", {
+        numberField: field(Number),
+        nome: field(String)
+        // customEntityFunction: function () { }
+      })
+
+      const givenAnSecondEntity = entity("Entity Two", {
+        entityField: field(givenAnFirstEntity),
+        // customEntityFunction: function () { }
+      })
+
+      // when
+      const gql = `${entity2input(givenAnFirstEntity)}
+      ${entity2input(givenAnSecondEntity)}`
+      
+
+      // then
+      assert.deepStrictEqual(
+        gql,
+        `input EntityOneInput {
+numberField: Float
+nome: String
+}
+      input EntityTwoInput {
+entityField: EntityOneInput
+}`
+      )
+    }) 
+  
 
     it("should convert an entity to input with convention", async () => {
       // given


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #43

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->
It adds support to use an entity as a field of another entity without error

## Proposed Changes

1. Added a parameter in the functions `entityField2gql` and `entityFieldType2gql`, so that it can identify when the function is creating a type and when it is an input type


## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request
- [x] Remember to check if code coverage decrease, if so, please implement the necessary tests

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
